### PR TITLE
Fix embedded asset names

### DIFF
--- a/main/web/html_content.cc
+++ b/main/web/html_content.cc
@@ -11,17 +11,17 @@
 #define HTML_STR(x) #x
 
 // 声明外部嵌入的HTML文件
-extern const uint8_t index_html_start[] asm("_binary_index_html_start");
-extern const uint8_t index_html_end[] asm("_binary_index_html_end");
+extern const uint8_t index_html_start[] asm("_binary_main_assets_html_index_html_start");
+extern const uint8_t index_html_end[] asm("_binary_main_assets_html_index_html_end");
 
-extern const uint8_t move_html_start[] asm("_binary_move_html_start");
-extern const uint8_t move_html_end[] asm("_binary_move_html_end");
+extern const uint8_t move_html_start[] asm("_binary_main_assets_html_move_html_start");
+extern const uint8_t move_html_end[] asm("_binary_main_assets_html_move_html_end");
 
-extern const uint8_t ai_html_start[] asm("_binary_ai_html_start");
-extern const uint8_t ai_html_end[] asm("_binary_ai_html_end");
+extern const uint8_t ai_html_start[] asm("_binary_main_assets_html_ai_html_start");
+extern const uint8_t ai_html_end[] asm("_binary_main_assets_html_ai_html_end");
 
-extern const uint8_t vision_html_start[] asm("_binary_vision_html_start");
-extern const uint8_t vision_html_end[] asm("_binary_vision_html_end");
+extern const uint8_t vision_html_start[] asm("_binary_main_assets_html_vision_html_start");
+extern const uint8_t vision_html_end[] asm("_binary_main_assets_html_vision_html_end");
 
 // HTML内容大小
 static size_t index_html_size = 0;

--- a/main/web/web_content.cc
+++ b/main/web/web_content.cc
@@ -813,39 +813,39 @@ esp_err_t WebContent::HandleCssFile(httpd_req_t* req) {
     
     // 尝试使用常见的CSS文件名模式
     if (strcmp(filename, "common.css") == 0) {
-        extern const uint8_t _binary_common_css_start[] asm("_binary_common_css_start");
-        extern const uint8_t _binary_common_css_end[] asm("_binary_common_css_end");
-        size_t len = _binary_common_css_end - _binary_common_css_start;
+        extern const uint8_t _binary_main_assets_html_css_common_css_start[] asm("_binary_main_assets_html_css_common_css_start");
+        extern const uint8_t _binary_main_assets_html_css_common_css_end[] asm("_binary_main_assets_html_css_common_css_end");
+        size_t len = _binary_main_assets_html_css_common_css_end - _binary_main_assets_html_css_common_css_start;
         ESP_LOGI(TAG, "发送common.css, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_common_css_start, len);
-    } 
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_css_common_css_start, len);
+    }
     else if (strcmp(filename, "index.css") == 0) {
-        extern const uint8_t _binary_index_css_start[] asm("_binary_index_css_start");
-        extern const uint8_t _binary_index_css_end[] asm("_binary_index_css_end");
-        size_t len = _binary_index_css_end - _binary_index_css_start;
+        extern const uint8_t _binary_main_assets_html_css_index_css_start[] asm("_binary_main_assets_html_css_index_css_start");
+        extern const uint8_t _binary_main_assets_html_css_index_css_end[] asm("_binary_main_assets_html_css_index_css_end");
+        size_t len = _binary_main_assets_html_css_index_css_end - _binary_main_assets_html_css_index_css_start;
         ESP_LOGI(TAG, "发送index.css, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_index_css_start, len);
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_css_index_css_start, len);
     }
     else if (strcmp(filename, "move.css") == 0) {
-        extern const uint8_t _binary_move_css_start[] asm("_binary_move_css_start");
-        extern const uint8_t _binary_move_css_end[] asm("_binary_move_css_end");
-        size_t len = _binary_move_css_end - _binary_move_css_start;
+        extern const uint8_t _binary_main_assets_html_css_move_css_start[] asm("_binary_main_assets_html_css_move_css_start");
+        extern const uint8_t _binary_main_assets_html_css_move_css_end[] asm("_binary_main_assets_html_css_move_css_end");
+        size_t len = _binary_main_assets_html_css_move_css_end - _binary_main_assets_html_css_move_css_start;
         ESP_LOGI(TAG, "发送move.css, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_move_css_start, len);
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_css_move_css_start, len);
     }
     else if (strcmp(filename, "ai.css") == 0) {
-        extern const uint8_t _binary_ai_css_start[] asm("_binary_ai_css_start");
-        extern const uint8_t _binary_ai_css_end[] asm("_binary_ai_css_end");
-        size_t len = _binary_ai_css_end - _binary_ai_css_start;
+        extern const uint8_t _binary_main_assets_html_css_ai_css_start[] asm("_binary_main_assets_html_css_ai_css_start");
+        extern const uint8_t _binary_main_assets_html_css_ai_css_end[] asm("_binary_main_assets_html_css_ai_css_end");
+        size_t len = _binary_main_assets_html_css_ai_css_end - _binary_main_assets_html_css_ai_css_start;
         ESP_LOGI(TAG, "发送ai.css, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_ai_css_start, len);
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_css_ai_css_start, len);
     }
     else if (strcmp(filename, "vision.css") == 0) {
-        extern const uint8_t _binary_vision_css_start[] asm("_binary_vision_css_start");
-        extern const uint8_t _binary_vision_css_end[] asm("_binary_vision_css_end");
-        size_t len = _binary_vision_css_end - _binary_vision_css_start;
+        extern const uint8_t _binary_main_assets_html_css_vision_css_start[] asm("_binary_main_assets_html_css_vision_css_start");
+        extern const uint8_t _binary_main_assets_html_css_vision_css_end[] asm("_binary_main_assets_html_css_vision_css_end");
+        size_t len = _binary_main_assets_html_css_vision_css_end - _binary_main_assets_html_css_vision_css_start;
         ESP_LOGI(TAG, "发送vision.css, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_vision_css_start, len);
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_css_vision_css_start, len);
     }
     
     // 如果没有找到匹配的CSS文件
@@ -889,39 +889,39 @@ esp_err_t WebContent::HandleJsFile(httpd_req_t* req) {
     
     // 尝试使用常见的JS文件名模式
     if (strcmp(filename, "api_client.js") == 0) {
-        extern const uint8_t _binary_api_client_js_start[] asm("_binary_api_client_js_start");
-        extern const uint8_t _binary_api_client_js_end[] asm("_binary_api_client_js_end");
-        size_t len = _binary_api_client_js_end - _binary_api_client_js_start;
+        extern const uint8_t _binary_main_assets_html_js_api_client_js_start[] asm("_binary_main_assets_html_js_api_client_js_start");
+        extern const uint8_t _binary_main_assets_html_js_api_client_js_end[] asm("_binary_main_assets_html_js_api_client_js_end");
+        size_t len = _binary_main_assets_html_js_api_client_js_end - _binary_main_assets_html_js_api_client_js_start;
         ESP_LOGI(TAG, "发送api_client.js, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_api_client_js_start, len);
-    } 
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_js_api_client_js_start, len);
+    }
     else if (strcmp(filename, "index.js") == 0) {
-        extern const uint8_t _binary_index_js_start[] asm("_binary_index_js_start");
-        extern const uint8_t _binary_index_js_end[] asm("_binary_index_js_end");
-        size_t len = _binary_index_js_end - _binary_index_js_start;
+        extern const uint8_t _binary_main_assets_html_js_index_js_start[] asm("_binary_main_assets_html_js_index_js_start");
+        extern const uint8_t _binary_main_assets_html_js_index_js_end[] asm("_binary_main_assets_html_js_index_js_end");
+        size_t len = _binary_main_assets_html_js_index_js_end - _binary_main_assets_html_js_index_js_start;
         ESP_LOGI(TAG, "发送index.js, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_index_js_start, len);
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_js_index_js_start, len);
     }
     else if (strcmp(filename, "move.js") == 0) {
-        extern const uint8_t _binary_move_js_start[] asm("_binary_move_js_start");
-        extern const uint8_t _binary_move_js_end[] asm("_binary_move_js_end");
-        size_t len = _binary_move_js_end - _binary_move_js_start;
+        extern const uint8_t _binary_main_assets_html_js_move_js_start[] asm("_binary_main_assets_html_js_move_js_start");
+        extern const uint8_t _binary_main_assets_html_js_move_js_end[] asm("_binary_main_assets_html_js_move_js_end");
+        size_t len = _binary_main_assets_html_js_move_js_end - _binary_main_assets_html_js_move_js_start;
         ESP_LOGI(TAG, "发送move.js, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_move_js_start, len);
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_js_move_js_start, len);
     }
     else if (strcmp(filename, "ai.js") == 0) {
-        extern const uint8_t _binary_ai_js_start[] asm("_binary_ai_js_start");
-        extern const uint8_t _binary_ai_js_end[] asm("_binary_ai_js_end");
-        size_t len = _binary_ai_js_end - _binary_ai_js_start;
+        extern const uint8_t _binary_main_assets_html_js_ai_js_start[] asm("_binary_main_assets_html_js_ai_js_start");
+        extern const uint8_t _binary_main_assets_html_js_ai_js_end[] asm("_binary_main_assets_html_js_ai_js_end");
+        size_t len = _binary_main_assets_html_js_ai_js_end - _binary_main_assets_html_js_ai_js_start;
         ESP_LOGI(TAG, "发送ai.js, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_ai_js_start, len);
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_js_ai_js_start, len);
     }
     else if (strcmp(filename, "vision.js") == 0) {
-        extern const uint8_t _binary_vision_js_start[] asm("_binary_vision_js_start");
-        extern const uint8_t _binary_vision_js_end[] asm("_binary_vision_js_end");
-        size_t len = _binary_vision_js_end - _binary_vision_js_start;
+        extern const uint8_t _binary_main_assets_html_js_vision_js_start[] asm("_binary_main_assets_html_js_vision_js_start");
+        extern const uint8_t _binary_main_assets_html_js_vision_js_end[] asm("_binary_main_assets_html_js_vision_js_end");
+        size_t len = _binary_main_assets_html_js_vision_js_end - _binary_main_assets_html_js_vision_js_start;
         ESP_LOGI(TAG, "发送vision.js, 大小: %d字节", (int)len);
-        return httpd_resp_send(req, (const char*)_binary_vision_js_start, len);
+        return httpd_resp_send(req, (const char*)_binary_main_assets_html_js_vision_js_start, len);
     }
     
     // 如果没有找到匹配的JS文件


### PR DESCRIPTION
## Summary
- fix symbol names for embedded HTML pages
- fix symbol names for CSS/JS assets served over HTTP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683bc5df0fe88329a29563bc6e91d642